### PR TITLE
Improve proteome extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamino-cli"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2021"
 description = "Build phylogenomic datasets in seconds."
 license = "MIT"
@@ -28,7 +28,7 @@ lto = "thin"
 codegen-units = 1
 opt-level = 3
 panic = "abort"
-debug = true
+debug = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use flate2::read::MultiGzDecoder;
-use hashbrown::HashMap;
 use rustc_hash::FxHasher;
 use seq_io::fasta::{Reader as FastaReader, Record};
 use std::fs::File;
@@ -20,7 +19,6 @@ use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 
 // Type alias for faster hashing
-type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 type FastDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 // ------------------------------
@@ -187,7 +185,6 @@ pub(crate) fn species_name_from_path(p: &std::path::Path) -> String {
 
 pub(crate) fn open_fasta(path: &Path) -> Result<Box<dyn Read>> {
     let f = File::open(path).with_context(|| format!("open {:?}", path))?;
-    // Larger buffer for better I/O throughput
     let buffered = BufReader::with_capacity(512 * 1024, f);
     let r: Box<dyn Read> = if let Some(s) = path.to_str() {
         if s.ends_with(".gz") {
@@ -215,9 +212,8 @@ pub fn build_graph_from_inputs(
 ) -> Result<()> {
     eprintln!("proteome files: {}", inputs.len());
 
+    // Register species with deterministic IDs
     main.init_species_len(inputs.len());
-
-    // Pre-register species sequentially for deterministic IDs
     let mut species_ids: Vec<u16> = Vec::with_capacity(inputs.len());
     for input in inputs {
         let sid = main.register_species(input.name.clone()) as u16;
@@ -230,7 +226,6 @@ pub fn build_graph_from_inputs(
 
     let k1 = k.saturating_sub(1);
     let min_needed = (min_freq * inputs.len().max(1) as f32).ceil() as u32;
-    // CMS estimates the number of species containing a (k-1)-mer.
     let min_needed_cms = min_needed;
 
     let pool = ThreadPoolBuilder::new()
@@ -238,13 +233,12 @@ pub fn build_graph_from_inputs(
         .build()
         .expect("Failed to build local Rayon thread pool");
 
-    // Thread-safe CMS updated in parallel; each species only increments once per k-mer.
+    // Pass 1: Build Count-Min Sketch (species frequency of each (k-1)-mer)
     let cms_atomic = AtomicCountMinSketch::new(CMS_WIDTH, CMS_DEPTH);
     pool.install(|| -> Result<()> {
         inputs.par_iter().try_for_each(|input| -> Result<()> {
             let rdr = open_fasta(&input.path)?;
             let mut reader = FastaReader::new(rdr);
-            // Per-species Bloom filter to prevent double-counting within a proteome.
             let mut species_bloom = BloomFilter::new(BLOOM_BITS);
 
             while let Some(rec) = reader.next() {
@@ -256,16 +250,16 @@ pub fn build_graph_from_inputs(
                     }
                 });
             }
-
             Ok(())
         })
     })?;
-    // Snapshot the CMS before the filtering stage.
     let cms = cms_atomic.snapshot();
 
+    // Shared structures for final graph
     let adj: FastDashMap<u64, u32> = FastDashMap::default();
     let samples: FastDashMap<u64, SpeciesSet> = FastDashMap::default();
 
+    // Pass 2: Main parallel processing (filter + edges + species tracking)
     pool.install(|| -> Result<()> {
         inputs
             .par_iter()
@@ -274,11 +268,8 @@ pub fn build_graph_from_inputs(
                 let rdr = open_fasta(&input.path)?;
                 let mut reader = FastaReader::new(rdr);
 
-                // Thread-local adjacency tracking (with_capacity needs further optimisation)
-                let mut local_adj: FastHashMap<u64, u32> = FastHashMap::with_capacity_and_hasher(
-                    1_000_000,
-                    BuildHasherDefault::<FxHasher>::default(),
-                );
+                // Collect all candidate edges from passing proteins
+                let mut transitions: Vec<(u64, u32)> = Vec::with_capacity(1_000_000);
 
                 let mut passed = 0usize;
                 let mut filtered = 0usize;
@@ -287,6 +278,7 @@ pub fn build_graph_from_inputs(
                     let rec = rec?;
                     let seq = rec.seq();
 
+                    // Filter protein using CMS
                     if !protein_passes_counts(
                         seq,
                         k1,
@@ -302,6 +294,7 @@ pub fn build_graph_from_inputs(
                     }
 
                     passed += 1;
+                    // Stream edges into temporary vector
                     stream_recoded_edges(
                         seq,
                         k1,
@@ -310,21 +303,28 @@ pub fn build_graph_from_inputs(
                         recode_scheme,
                         |u, sym, _v| {
                             let bit = 1u32 << sym;
-                            *local_adj.entry(u).or_insert(0) |= bit;
+                            transitions.push((u, bit));
                         },
                     );
                 }
 
+                // Optimisation 1: Aggregate edges with sort + linear scan
                 let mut kept = 0usize;
                 let mut dropped = 0usize;
 
-                // Pre-allocate based on expected filtering
-                let estimated = local_adj.len(); // 95%+ pass rate
-                let mut adj_updates: Vec<(u64, u32)> = Vec::with_capacity(estimated);
-                let mut node_updates: Vec<u64> = Vec::with_capacity(estimated * 2);
+                transitions.sort_unstable_by_key(|(u, _)| *u);
 
-                // Filter: keep only nodes with out-degree == 1
-                for (&u, &mask) in &local_adj {
+                let mut adj_updates: Vec<(u64, u32)> = Vec::with_capacity(1_000_000);
+                let mut node_updates: Vec<u64> = Vec::with_capacity(2_000_000);
+
+                let mut i = 0;
+                while i < transitions.len() {
+                    let u = transitions[i].0;
+                    let mut mask = 0u32;
+                    while i < transitions.len() && transitions[i].0 == u {
+                        mask |= transitions[i].1;
+                        i += 1;
+                    }
                     if mask == 0 {
                         continue;
                     }
@@ -345,8 +345,7 @@ pub fn build_graph_from_inputs(
                     kept += 1;
                 }
 
-                // Drop local_adj early to free memory
-                drop(local_adj);
+                drop(transitions);
 
                 let proteins_total = passed + filtered;
                 let kmers_total = kept + dropped;
@@ -355,24 +354,19 @@ pub fn build_graph_from_inputs(
                     input.name, passed, proteins_total, kept, kmers_total
                 );
 
-                // Batch merge adjacency
+                // Merge edges into shared adjacency table
                 for (node, mask) in adj_updates {
                     adj.entry(node).and_modify(|m| *m |= mask).or_insert(mask);
                 }
 
-                // Sort and dedup nodes
+                // Optimisation 2: Collect species per node (push + final sort)
                 node_updates.sort_unstable();
                 node_updates.dedup();
 
-                // Batch update samples
                 for node in node_updates {
                     samples
                         .entry(node)
-                        .and_modify(|species_set| {
-                            if let Err(pos) = species_set.binary_search(&sid) {
-                                species_set.insert(pos, sid);
-                            }
-                        })
+                        .and_modify(|species_set| species_set.push(sid))
                         .or_insert_with(|| {
                             let mut set = SpeciesSet::new();
                             set.push(sid);
@@ -384,6 +378,12 @@ pub fn build_graph_from_inputs(
             })
     })?;
 
+    // Sort all SpeciesSets
+    samples.iter_mut().for_each(|mut entry| {
+        entry.value_mut().sort_unstable();
+    });
+
+    // Build final graph structures
     main.adj = AdjTable::from_iter(adj);
     main.samples = NodeColorTable::from_iter(samples, main.n_species);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!   selected recoding scheme).
 //! - `-f`, `--min-freq`: minimum fraction of samples with an amino-acid per position
 //!   (default: 0.85; must be ≥ 0.6).
-//! - `-d`, `--depth`: maximum traversal depth from each start node (default: 8).
+//! - `-d`, `--depth`: maximum traversal depth from each start node (default: 12).
 //! - `-o`, `--output`: output prefix for generated files (default: `kamino`).
 //! - `-c`, `--constant`: number of constant positions retained from in-bubble k-mers
 //!   (default: 3; must be ≤ k-1).
@@ -53,9 +53,10 @@
 //! increasing it usually does not substantially increase the number of variant groups. It may,
 //! however, be useful to decrease the k-mer size from 14 to 13 if memory consumption is too high.
 //!
-//! Increasing the depth of the recursive graph traversal (e.g. from 8 to 10) generally increases
+//! Increasing the depth of the recursive graph traversal (e.g. from 12 to 16) generally increases
 //! the size of the final alignment, as kamino detects more variant groups during graph traversal.
-//! This is typically the most effective approach if the alignment is deemed too short.
+//! This is typically the most effective approach if the alignment is deemed too short, but results 
+//! in increased runtimes as the program spends more time traversing the graph.
 //!
 //! Finally, larger alignments can also be produced by decreasing the minimum fraction of samples
 //! required to carry an amino acid (e.g. from 0.85 to 0.8), at the cost of increased missing data
@@ -220,8 +221,8 @@ pub struct Args {
     )]
     pub min_freq: f32,
 
-    /// Maximum traversal depth from each start node [d=8]
-    #[arg(short, long, default_value_t = 8, hide_default_value = true)]
+    /// Maximum traversal depth from each start node [d=12]
+    #[arg(short, long, default_value_t = 12, hide_default_value = true)]
     pub depth: usize,
 
     /// Output prefix [o=kamino]

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -166,6 +166,7 @@ struct Frame {
 /// - Initializes the species reference set from the start node and progressively refines it
 ///   using intersections involving the previous and current node at bifurcations.
 /// - On reaching an end, records the accumulated species set with the path.
+#[allow(clippy::too_many_arguments)]
 fn collect_paths_iterative_species_from_last_bifurcation(
     g: &Graph,
     start: u64,

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -5,6 +5,7 @@ use bitvec::prelude::*;
 use hashbrown::{HashMap, HashSet};
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
+use std::rc::Rc;
 
 /// One path with the species set accumulated through bifurcations
 #[derive(Clone)]
@@ -92,6 +93,7 @@ fn collect_variant_groups(
     let mut starts_sorted: Vec<u64> = start_kmers.iter().copied().collect();
     starts_sorted.sort_unstable();
 
+
     // Build a local Rayon thread pool with the requested number of threads
     let n_threads = num_threads.max(1);
     let pool = ThreadPoolBuilder::new()
@@ -113,6 +115,7 @@ fn collect_variant_groups(
                     max_depth,
                     mask_k1,
                     min_path_edges,
+                    max_allowed_len,
                     &mut per_start,
                 );
 
@@ -124,7 +127,7 @@ fn collect_variant_groups(
                 for key in keys {
                     if let Some(paths) = per_start.remove(&key) {
                         if let Some((k, v)) =
-                            filter_one_group_3steps(g, key, paths, need, n_species, max_allowed_len)
+                            filter_one_group_3steps(g, key, paths, need, n_species)
                         {
                             kept_local.insert(k, v);
                         }
@@ -142,7 +145,7 @@ fn collect_variant_groups(
                 all_kept.insert(k, v);
             }
         }
-
+        
         // Final global selection
         post_select_variant_groups(all_kept, g)
     })
@@ -154,7 +157,7 @@ struct Frame {
     next_mask: u32,                 // unexplored outgoing edges (bitmask)
     total_outdeg: usize,            // total outdegree of this node
     solved: usize,                  // # internal bifurcations crossed (exclude start)
-    ref_species: BitVec<u32, Lsb0>, // cumulative species reference set for the path
+    ref_species: Rc<BitVec<u32, Lsb0>>, // cumulative species reference set for the path (now shared via Rc)
     emitted: bool,                  // whether this path ending was already recorded
 }
 
@@ -170,6 +173,7 @@ fn collect_paths_iterative_species_from_last_bifurcation(
     max_depth: usize,
     mask_k1: u64,
     min_path_edges: usize,
+    max_allowed_len: usize,
     out: &mut VariantGroups,
 ) {
     let start_mask = g.adj.get(start).unwrap_or(0);
@@ -182,12 +186,12 @@ fn collect_paths_iterative_species_from_last_bifurcation(
     let mut on_path: HashSet<u64, RandomState> =
         HashSet::with_capacity_and_hasher(128, RandomState::new());
 
-    let mut species_cache: HashMap<u64, BitVec<u32, Lsb0>, RandomState> =
+    let mut species_cache: HashMap<u64, Rc<BitVec<u32, Lsb0>>, RandomState> =
         HashMap::with_capacity_and_hasher(128, RandomState::new());
 
-    let mut get_species = |node: u64| {
-        if let Some(bits) = species_cache.get(&node) {
-            return bits.clone();
+    let mut get_species = |node: u64| -> Rc<BitVec<u32, Lsb0>> {
+        if let Some(rc) = species_cache.get(&node) {
+            return Rc::clone(rc);
         }
 
         let bits = g
@@ -196,8 +200,9 @@ fn collect_paths_iterative_species_from_last_bifurcation(
             .map(|bs| bs.to_bitvec())
             .unwrap_or_else(|| BitVec::repeat(false, g.n_species));
 
-        species_cache.insert(node, bits.clone());
-        bits
+        let rc = Rc::new(bits);
+        species_cache.insert(node, Rc::clone(&rc));
+        rc
     };
 
     // Start species = species at start node
@@ -220,7 +225,7 @@ fn collect_paths_iterative_species_from_last_bifurcation(
     while let Some(mut fr) = stack.pop() {
         // Reached an end and path long enough: Emit path, materializing the species only now.
         if !fr.emitted && end_kmers.contains(&fr.node) && path.len() > min_path_edges {
-            let species = fr.ref_species.clone();
+            let species = fr.ref_species.as_ref().clone();
 
             // In the node-based graph, the path is already explicit
             let full_nodes = path.clone();
@@ -249,7 +254,12 @@ fn collect_paths_iterative_species_from_last_bifurcation(
             if on_path.contains(&next) {
                 continue;
             }
-
+            
+            // Stop traversal if maximum length reached
+            if path.len() > max_allowed_len {
+                continue;
+            }
+            
             // Depth control: increment when *leaving* an internal bifurcation (not the start)
             let parent = stack.last().unwrap();
             let cur_outdeg = parent.total_outdeg;
@@ -264,37 +274,41 @@ fn collect_paths_iterative_species_from_last_bifurcation(
                 continue;
             }
 
-            // ---------- NEW SPECIES LOGIC ----------
-            let mut next_ref_species = parent.ref_species.clone();
+            // ---------- OPTIMIZED SPECIES LOGIC ----------
+            // Use Rc sharing: linear segments (non-bifurcations) now only clone the Rc pointer.
+            // Intersection (expensive BitVec data clone) only happens at start / real bifurcations.
+            let mut next_ref_species = Rc::clone(&parent.ref_species);
 
             if parent.node == start {
                 // First step: species = S(start) ∩ S(next)
                 let next_species = get_species(next);
-                if next_ref_species.len() < next_species.len() {
-                    next_ref_species.resize(next_species.len(), false);
+                let owned = Rc::make_mut(&mut next_ref_species);
+                if owned.len() < next_species.len() {
+                    owned.resize(next_species.len(), false);
                 }
-                next_ref_species &= next_species.as_bitslice();
+                *owned &= next_species.as_bitslice();
             } else if parent.total_outdeg > 1 {
                 // At a real bifurcation:
                 //   species_new = current_ref ∩ S(parent) ∩ S(next)
                 let parent_species = get_species(parent.node);
-                if next_ref_species.len() < parent_species.len() {
-                    next_ref_species.resize(parent_species.len(), false);
-                }
-                next_ref_species &= parent_species.as_bitslice();
-
                 let next_species = get_species(next);
-                if next_ref_species.len() < next_species.len() {
-                    next_ref_species.resize(next_species.len(), false);
+                let owned = Rc::make_mut(&mut next_ref_species);
+                if owned.len() < parent_species.len() {
+                    owned.resize(parent_species.len(), false);
                 }
-                next_ref_species &= next_species.as_bitslice();
+                *owned &= parent_species.as_bitslice();
+
+                if owned.len() < next_species.len() {
+                    owned.resize(next_species.len(), false);
+                }
+                *owned &= next_species.as_bitslice();
             } else {
                 // Non-branching internal node:
-                // keep current ref_species as-is for now.
+                // Keep the shared Rc (no data clone)
             }
-            // ---------- END NEW SPECIES LOGIC ----------
+            // ---------- END OPTIMIZED SPECIES LOGIC ----------
 
-            if parent.node != start && parent.total_outdeg > 1 && !next_ref_species.any() {
+            if parent.node != start && parent.total_outdeg > 1 && next_ref_species.as_ref().count_ones() == 0 {
                 continue;
             }
 
@@ -333,7 +347,6 @@ fn filter_one_group_3steps(
     paths: Vec<PathRec>,
     need: usize,
     n_species: usize,
-    max_allowed_len: usize,
 ) -> Option<((u64, u64), Vec<PathRec>)> {
     // (i) Choose path length by union species across paths of that length
     let mut unions_by_len: HashMap<usize, BitVec<u32, Lsb0>> = HashMap::new();
@@ -365,10 +378,6 @@ fn filter_one_group_3steps(
         return None; // ambiguous best length
     }
     let keep_len = items[0].0;
-
-    if keep_len > max_allowed_len {
-        return None;
-    }
 
     // Keep only paths of the chosen length
     let kept_paths: Vec<PathRec> = paths


### PR DESCRIPTION
- improved efficiency of proteome extraction and graph traversal
- added stopping criterion for graph traversal based on path length and removed filtering of variant groups based on sequence length (same output; the former is faster)
- increased default maximum recursive depth from 8 to 12